### PR TITLE
Fix static on first start of FM after BT activation (really)

### DIFF
--- a/res/values-nl/arrays.xml
+++ b/res/values-nl/arrays.xml
@@ -1,80 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string-array name="bt_exit_behaviour_entries">
-    <item>Doe niets (Blijft geactiveerd)</item>
-    <item>Herstel initiële BT staat</item>
-    <item>Prompt voor gebruikers actie</item>
+    <item>Niets doen (blijft ingeschakeld)</item>
+    <item>Oorspronkelijke Bluetooth-stand herstellen</item>
+    <item>Melding voor gebruiker tonen</item>
     <item>Altijd uitzetten</item>
   </string-array>
-
   <string-array name="ster_mon_entries">
     <item>Stereo</item>
     <item>Mono</item>
   </string-array>
-
   <string-array name="record_durations_entries">
     <item>5 minuten</item>
     <item>15 minuten</item>
     <item>30 minuten</item>
     <item>Ongelimiteerd</item>
   </string-array>
-
   <string-array name="search_category_rbds_entries">
     <item>Alle stations</item>
     <item>Erotiek</item>
     <item>Klassiek</item>
     <item>Klassieke rock</item>
-    <item>College</item>
+    <item>Onderwijs</item>
     <item>Country</item>
     <item>Nood</item>
-    <item>Nood Test</item>
-    <item>Buitenlandse taal</item>
+    <item>Noodtest</item>
+    <item>Anderstalig</item>
     <item>Informatie</item>
     <item>Jazz</item>
     <item>Nieuws</item>
     <item>Nostalgie</item>
-    <item>Oldies</item>
+    <item>Gouwe ouwe</item>
     <item>Personaliteit</item>
     <item>Publiek</item>
-    <item>Religieuze Muziek</item>
-    <item>Religieuze Praat</item>
-    <item>Rhythm and Blues</item>
+    <item>Religieuze muziek</item>
+    <item>Religieuze praat</item>
+    <item>Rhythm-and-Blues</item>
     <item>Rock</item>
     <item>Soft</item>
-    <item>Soft Rock</item>
-    <item>Soft Rhythm and Blues</item>
+    <item>Softrock</item>
+    <item>Softrhythm-and-blues</item>
     <item>Sport</item>
-    <item>Praatshow</item>
+    <item>Praatprogramma\'s</item>
     <item>Top 40</item>
     <item>Weer</item>
   </string-array>
-
   <string-array name="search_category_rds_entries">
     <item>Alle stations</item>
     <item>Cultuur</item>
     <item>Huidige zaken</item>
     <item>Kinderprogramma\'s</item>
-    <item>Country Muziek</item>
+    <item>Countrymuziek</item>
     <item>Documentaire</item>
     <item>Drama</item>
-    <item>Muziek wat lekker weg luisterd</item>
+    <item>Easy listening</item>
     <item>Educatie</item>
     <item>Nood</item>
-    <item>Nood Test</item>
+    <item>Noodtest</item>
     <item>Financieel</item>
-    <item>Volks Muziek</item>
+    <item>Volksmuziek</item>
     <item>Informatie</item>
-    <item>Jazz Muziek</item>
+    <item>Jazzmuziek</item>
     <item>Licht klassiek</item>
     <item>Vrije tijd</item>
-    <item>Niews</item>
-    <item>Muziek in eigen taal</item>
+    <item>Nieuws</item>
+    <item>Nederlandstalig</item>
     <item>Andere muziek</item>
-    <item>Oldies</item>
-    <item>Phone In</item>
-    <item>Pop Muziek</item>
+    <item>Gouwe ouwe</item>
+    <item>Belprogramma</item>
+    <item>Popmuziek</item>
     <item>Religieus</item>
-    <item>Rock Muziek</item>
+    <item>Rockmuziek</item>
     <item>Wetenschappelijk</item>
     <item>Serieus klassiek</item>
     <item>Sociale zaken</item>
@@ -83,18 +79,16 @@
     <item>Gevarieërd</item>
     <item>Weer</item>
   </string-array>
-
   <string-array name="presetlist_edit_category">
-    <item>Hernoem</item>
-    <item>Selecteer automatisch</item>
+    <item>Hernoemen</item>
+    <item>Automatisch selecteren</item>
     <item>Verwijder</item>
   </string-array>
-
   <string-array name="regional_band_entries">
     <item>Noord-Amerika</item>
     <item>Europa</item>
     <item>Japan</item>
-    <item>Japan (Wide)</item>
+    <item>Japan (breed)</item>
     <item>Australië</item>
     <item>Oostenrijk</item>
     <item>België</item>
@@ -113,7 +107,7 @@
     <item>Korea</item>
     <item>Mexico</item>
     <item>Nederland</item>
-    <item>Niew Zeeland</item>
+    <item>Nieuw-Zeeland</item>
     <item>Noorwegen</item>
     <item>Polen</item>
     <item>Portugal</item>
@@ -125,46 +119,45 @@
     <item>Zweden</item>
     <item>Taiwan</item>
     <item>Turkije</item>
-    <item>Verenigd Koningkrijk</item>
+    <item>Verenigd Koninkrijk</item>
     <item>Verenigde Staten</item>
   </string-array>
-
   <string-array name="regional_band_summary">
-    <item>Noord Amerika (87.5MHz tot 108.0MHz In 200 Khz Stappen)</item>
-    <item>Europa (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Japan (76.0MHz tot  90.0MHz In 100 Khz Stappen)</item>
-    <item>Japan (Wide) (90.0MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Australië (87.7MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Oostenrijk (87.5MHz tot 108.0MHz In  50 Khz Stappen)</item>
-    <item>België (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Brazilië (87.8MHz tot 108.0MHz In 200 Khz Step)</item>
-    <item>China (87.0MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Tsjechië (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Denemarken (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Finland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Frankrijk (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Duitsland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Griekenland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Hong Kong (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>India (91.0MHz tot 106.4MHz In 100 Khz Stappen)</item>
-    <item>Ierland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Italië (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Korea (87.5MHz tot 108.0MHz In 200 Khz Stappen)</item>
-    <item>Mexico (88.1MHz tot 107.9MHz In 200 Khz Stappen)</item>
-    <item>Nederland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Nieuw Zeeland (88.0MHz tot 107.0MHz In 100 Khz Stappen)</item>
-    <item>Noorwegen (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Polen (88.0MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Portugal (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Rusland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Singapore (88.0MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Slowakije (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Spanje (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Zwitserland (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Zweden (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Taiwan (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Turkije (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Verenigd Koninkrijk (87.5MHz tot 108.0MHz In 100 Khz Stappen)</item>
-    <item>Verenigde Staten (88.1MHz tot 107.9MHz In 200 Khz Stappen)</item>
+    <item>Noord-Amerika (87.5MHz tot 108.0MHz in stappen van 200 kHz)</item>
+    <item>Europa (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Japan (76.0MHz tot  90.0MHz in stappen van 100 kHz)</item>
+    <item>Japan (Wide) (90.0MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Australië (87.7MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Oostenrijk (87.5MHz tot 108.0MHz in stappen van 50 kHz)</item>
+    <item>België (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Brazilië (87.8MHz tot 108.0MHz in stappen van 200 kHz)</item>
+    <item>China (87.0MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Tsjechië (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Denemarken (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Finland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Frankrijk (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Duitsland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Griekenland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Hong Kong (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>India (91.0MHz tot 106.4MHz in stappen van 100 kHz)</item>
+    <item>Ierland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Italië (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Korea (87.5MHz tot 108.0MHz in stappen van 200 kHz)</item>
+    <item>Mexico (88.1MHz tot 107.9MHz in stappen van 200 kHz)</item>
+    <item>Nederland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Nieuw-Zeeland (88.0MHz tot 107.0MHz in stappen van 100 kHz)</item>
+    <item>Noorwegen (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Polen (88.0MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Portugal (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Rusland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Singapore (88.0MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Slowakije (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Spanje (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Zwitserland (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Zweden (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Taiwan (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Turkije (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Verenigd Koninkrijk (87.5MHz tot 108.0MHz in stappen van 100 kHz)</item>
+    <item>Verenigde Staten (88.1MHz tot 107.9MHz in stappen van 200 kHz)</item>
   </string-array>
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -1,64 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">FM Radio</string>
+    <string name="app_name">FM-radio</string>
     <string name="tx_app_name">FM-transmitter</string>
-    <string name="preset_delete">Verwijder</string>
+    <string name="preset_delete">Verwijderen</string>
+    <string name="preset_rename">Hernoemen</string>
+    <string name="dialog_presetlist_rename_title">Naam invoeren </string>
     <string name="stat_notif_frequency">Frequentie: "<xliff:g id="frequency">%1$s</xliff:g>" MHz</string>
-
-    <string name="sel_band_menu">Selecteer regionale band</string>
+    <string name="sel_band_menu">Regionale band selecteren</string>
     <string name="settings_menu">Instellingen</string>
     <string name="regional_band">Regionale band</string>
-
-    <string name="aud_output_mode">Audio uitvoer modus</string>
-    <string name="sel_audio_output">Selecteer audio uitvoer</string>
-
-    <string name="record_dur">Duur van opname</string>
-    <string name="sel_rec_dur">Selecteer opname duur</string>
-
+    <string name="aud_output_mode">Audio-uitvoermodus</string>
+    <string name="sel_audio_output">Selecteer audio-uitvoer</string>
+    <string name="record_dur">Opnameduur</string>
+    <string name="sel_rec_dur">Opnameduur selecteren</string>
     <string name="auto_select_af">Alternatieve frequentie</string>
-    <string name="auto_select_af_enabled">Automatisch selecteren geactiveerd</string>
-    <string name="auto_select_af_disabled">Automatisch selecteren uitgezet</string>
-
-    <string name="fac_defaults">Reset instellingen</string>
-    <string name="revert_to_fac">Reset instellingen</string>
+    <string name="auto_select_af_enabled">Automatisch selecteren ingeschakeld</string>
+    <string name="auto_select_af_disabled">Automatisch selecteren uitgeschakeld</string>
+    <string name="fac_defaults">Instellingen herstellen</string>
+    <string name="revert_to_fac">Instellingen herstellen</string>
     <string name="settings_back">Terug</string>
-
-    <string name="settings_revert_confirm_title">Bevestig reset</string>
-    <string name="settings_revert_confirm_msg">Dit verwijderd alle instellingen!</string>
-
+    <string name="settings_revert_confirm_title">Herstel bevestigen</string>
+    <string name="settings_revert_confirm_msg">Hierdoor worden al uw instellingen verwijderd</string>
     <string name="settings_back_summary">Terug naar vorige weergave</string>
-    <string name="settings_revert_defaults_title">Reset instellingen</string>
-    <string name="settings_revert_defaults_summary">Reset instellingen naar de standaard waarden</string>
-
+    <string name="settings_revert_defaults_title">Instellingen herstellen</string>
+    <string name="settings_revert_defaults_summary">Standaardinstellingen terugzetten</string>
     <string name="alert_dialog_ok">OK</string>
     <string name="alert_dialog_cancel">Annuleren</string>
-
     <string name="preset_search">Zoeken"<xliff:g id="preset_pi">%1$s</xliff:g>"</string>
-
-    <string name="fm_command_failed_title">FM operatie mislukt</string>
-    <string name="fm_cmd_failed_msg">De operatie is mislukt. Mogelijke oorzaken: De bedraade hoofdtelefoon antenne is niet aangesloten, Bluetooth is niet geactiveerd, er is een telefoongesprek gaande, of FM is afgesloten. Controleer dit en probeer het vervolgens opnieuw.</string>
-
+    <string name="fm_command_failed_title">FM-operatie mislukt</string>
+    <string name="fm_cmd_failed_msg">De operatie is mislukt. Mogelijke oorzaken: er is geen koptelefoon met antenne aangesloten, Bluetooth is niet ingeschakeld, een telefoongesprek is bezig, of FM is afgesloten. Gelieve dit te controleren en daarna opnieuw te proberen.</string>
     <string name="frequency_string"></string>
-    <string name="stat_no_fm">FM radio staat niet aan</string>
-
-    <!-- Added by LIBRA -->
-    <string name="need_headset_for_antenna">Sluit een bedraadde hoofdtelefoon aan, deze zal als FM antenne gebruikt worden.</string>
-    <string name="init_FM">Zet Bluetooth aan voor FM radio ondersteuning..</string>
-    <string name="need_bluetooth">Zet Bluetooth aan a.u.b.</string>
-
+    <string name="stat_no_fm">FM-radio niet ingeschakeld</string>
+    <string name="need_headset_for_antenna">Gelieve een koptelefoon met een FM-antenne aan te sluiten.</string>
+    <string name="init_FM">Bluetooth aanzetten voor ondersteuning voor FM-radio\u2026</string>
+    <string name="need_bluetooth">Gelieve Bluetooth aan te zetten</string>
     <string name="about_title">Over</string>
-    <string name="about_summary">FM Radio app ontwikkeld door MIUI - http://www.miui.com</string>
-
-    <string name="pref_disable_bt_prompt_title">Prompt om BT voor radio uit te zetten</string>
-    <string name="pref_disable_bt_prompt_summary">Prompt gebruiker om Bluetooth uit te zetten wanneer de radio uitgeschakeld wordt</string>
-    <string name="prompt_disable_bt">Wil je Bluetooth uitzetten?</string>
+    <string name="about_summary">FM-radioapplicatie, ontwikkeld door MIUI - http://www.miui.com</string>
+    <string name="pref_disable_bt_prompt_title">Melding voor uitschakeling Bluetooth indien applicatie wordt afgesloten</string>
+    <string name="pref_disable_bt_prompt_summary">Melding tonen om Bluetooth uit te schakelen indien de FM-radio wordt uitgeschakeld</string>
+    <string name="prompt_disable_bt">Wilt u Bluetooth uitschakelen?</string>
     <string name="prompt_yes">Ja</string>
     <string name="prompt_no">Nee</string>
-
-    <string name="pref_bt_behaviour_on_exit_title">Bluetooth gedrag in radio staat uit</string>
-    <string name="pref_bt_behaviour_on_exit_summary">Altijd uitschakelen, herstel initiële staat, promt, etc.</string>
-    <string name="pref_bt_behaviour_on_exit_dialog_title">Kies Bluetooth gedrag</string>
-
-    <string name="pref_headset_behaviour_title">Hoofdtelefoon en Bluetooth gedrag</string>
-    <string name="pref_headset_behaviour_summary">Roep Bluetooth gedrag aan wanneer hoofdtelefoon wordt losgekoppeld</string>
+    <string name="pref_bt_behaviour_on_exit_title">Bluetooth-gedrag indien FM-radio wordt uitgeschakeld</string>
+    <string name="pref_bt_behaviour_on_exit_summary">Altijd uitschakelen, begintoestand herstellen, melden, etc.</string>
+    <string name="pref_bt_behaviour_on_exit_dialog_title">Bluetooth-gedrag kiezen</string>
+    <string name="pref_headset_behaviour_title">Koptelefoon &amp; Bluetooth-gedrag</string>
+    <string name="pref_headset_behaviour_summary">Bluetooth-gedrag inschakelen indien koptelefoon wordt losgekoppeld</string>
 </resources>

--- a/res/values-sk/arrays.xml
+++ b/res/values-sk/arrays.xml
@@ -3,15 +3,10 @@
 <resources>
 
   <string-array name="bt_exit_behaviour_entries">
-    <item>Neurobiť nič (Zostáva povolené)</item>
+    <item>Neurobiť nič (zostáva povolené)</item>
     <item>Obnoviť počiatočný stav BT</item>
     <item>Opýtať sa na užívateľskú akciu</item>
     <item>Vždy zakázať</item>
-  </string-array>
-
-  <string-array name="ster_mon_entries">
-    <item>Stereo</item>
-    <item>Mono</item>
   </string-array>
 
   <string-array name="record_durations_entries">
@@ -22,14 +17,14 @@
   </string-array>
 
 <string-array name="search_category_rbds_entries">
-    <item>Všetky Stanice</item>
-    <item>Hity pre Dospelých</item>
+    <item>Všetky stanice</item>
+    <item>Hity pre dospelých</item>
     <item>Klasické</item>
-    <item>Klasický Rock</item>
-    <item>Kolégium</item>
+    <item>Klasický rock</item>
+    <item>Školské</item>
     <item>Country</item>
-    <item>Pohotovosť</item>
-    <item>Test Pohotovosti</item>
+    <item>Núdzové</item>
+    <item>Testovanie núdzových</item>
     <item>Cudzí jazyk</item>
     <item>Informačné</item>
     <item>Jazz</item>
@@ -38,48 +33,48 @@
     <item>Starinky</item>
     <item>Osobné</item>
     <item>Verejné</item>
-    <item>Náboženská Hudba</item>
-    <item>Náboženské Hovory</item>
+    <item>Náboženská hudba</item>
+    <item>Náboženské rozhovory</item>
     <item>Rhythm and Blues</item>
     <item>Rock</item>
     <item>Soft</item>
     <item>Soft Rock</item>
     <item>Soft Rhythm and Blues</item>
     <item>Šport</item>
-    <item>Hovory</item>
+    <item>Hovorené slovo</item>
     <item>Top 40</item>
     <item>Počasie</item>
   </string-array>
 
   <string-array name="search_category_rds_entries">
-    <item>Všetky Stanice</item>
+    <item>Všetky stanice</item>
     <item>Kultúra</item>
-    <item>Súčasné Udalosti</item>
+    <item>Aktuálne udalosti</item>
     <item>Detské programy</item>
-    <item>Country Hudba</item>
+    <item>Country hudba</item>
     <item>Dokumentárne</item>
     <item>Dráma</item>
     <item>Hudba na ľahké počúvanie</item>
     <item>Vzdelávanie</item>
     <item>Pohotovosť</item>
-    <item>Test Pohotovosti</item>
+    <item>Test pohotovosti</item>
     <item>Finančné</item>
-    <item>Folková Hudba</item>
-    <item>informačné</item>
-    <item>Jazzová Hudba</item>
-    <item>Ľahká Klasika</item>
+    <item>Folková hudba</item>
+    <item>Informačné</item>
+    <item>Jazzová hudba</item>
+    <item>Ľahká klasika</item>
     <item>Oddych</item>
     <item>Správy</item>
-    <item>Národná Hudba</item>
-    <item>Iná Hudba</item>
-    <item>Stará Hudba</item>
+    <item>Národná hudba</item>
+    <item>Iná hudba</item>
+    <item>Staršia hudba</item>
     <item>Phone In</item>
-    <item>Pop Hudba</item>
-    <item>Náboženské</item>
-    <item>Rocková Hudba</item>
+    <item>Populárna hudba</item>
+    <item>Náboženská</item>
+    <item>Rocková hudba</item>
     <item>Veda</item>
     <item>Vážna klasika</item>
-    <item>Sociálne Udalosti</item>
+    <item>Sociálne veci</item>
     <item>Šport</item>
     <item>Cestovanie</item>
     <item>Rôzne</item>
@@ -88,8 +83,8 @@
 
   <string-array name="presetlist_edit_category">
     <item>Premenovať</item>
-    <item>Automatický Výber</item>
-    <item>Zmazať</item>
+    <item>Automatický výber</item>
+    <item>Vymazať</item>
   </string-array>
 
 

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -3,6 +3,8 @@
     <string name="app_name">FM Rádio</string>
     <string name="tx_app_name">FM Vysielač</string>
     <string name="preset_delete">Zmazať</string>
+    <string name="preset_rename">Premenovať</string>
+    <string name="dialog_presetlist_rename_title">Zadajte názov </string>
     <string name="stat_notif_frequency">Frekvencia: "<xliff:g id="frequency">%1$s</xliff:g>" MHz</string>
 
     <string name="sel_band_menu">Vyberte regionálne pásmo</string>

--- a/src/com/android/fm/radio/FMRadio.java
+++ b/src/com/android/fm/radio/FMRadio.java
@@ -939,11 +939,11 @@ public class FMRadio extends Activity {
                     if (isAntennaAvailable()) {
                         mFreqIndicator.setFrequency(FmSharedPreferences.getTunedFrequency());
 
-                        boolean radioOn = mService.isFmOn();
-
-                        if (!radioOn) {
-                            // Set the previously tuned frequency
+                        if (FmSharedPreferences.getTunedFrequency() != mService.getFreq()) {
+                            // Ensure the previously tuned frequency is set
+                            muteFMAudioStream(500);
                             tuneRadio(FmSharedPreferences.getTunedFrequency());
+                            unMuteFMAudioStream();
                         }
 
                         // Get the audio focus and unmute the FM radio


### PR DESCRIPTION
The application will now compare the last saved frequency to the
currently tuned frequency, and set to the last saved frequency
if they do not match.
